### PR TITLE
feat(design): Set Quintessential as official headline font

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10,8 +10,9 @@
   --accent-hover-color: #5f6f9a; 
   
   /* --- FINAL FONT VARIABLES --- */
-  --headline-font: 'Patrick Hand', cursive; 
-  --body-font: 'DM Sans', sans-serif;
+  /* --headline-font: 'Patrick Hand', cursive;  */
+  --headline-font: var(--font-quintessential); 
+  --body-font: var(--font-dm-sans);
 }
 
 * {
@@ -30,6 +31,7 @@ body {
 
 h1, h2, h3, h4, h5, h6 {
   font-family: var(--headline-font);
+  font-weight: 400; 
   /* Patrick Hand is a single weight, so font-weight is not needed here */
   /* We can adjust letter-spacing for a slightly different feel if needed */
   letter-spacing: 0.5px;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,23 @@
 import type { Metadata } from "next";
 import "./globals.css";
 
+import { Quintessential, DM_Sans } from 'next/font/google'; // Import Quintessential
+import './globals.css';
+
+// Setup for the new headline font (Quintessential)
+const quintessential = Quintessential({
+  subsets: ['latin'],
+  weight: ['400'], // Quintessential only has one weight: 400 (Regular).
+  variable: '--font-quintessential', // Create the CSS variable
+});
+
+// The body font setup remains the same
+const dmSans = DM_Sans({
+  subsets: ['latin'],
+  weight: ['400', '500'],
+  variable: '--font-dm-sans',
+});
+
 // --- FINAL: Updated metadata for SEO, brand identity, and community building ---
 export const metadata: Metadata = {
   title: "Helm | The AI Meeting Assistant for Thoughtful Professionals",
@@ -27,7 +44,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" className={`${quintessential.variable} ${dmSans.variable}`}>
       <body>{children}</body>
     </html>
   );


### PR DESCRIPTION
## Description

This PR replaces the previous unreliable font-loading method with the professional `next/font` system. It fixes an issue where headings were rendering with a local fallback font (`Apple Chancery`) on some devices and a different system font on others.

We have selected **Quintessential** as the new, official headline font to establish a consistent and elegant brand identity across all platforms.

### Key Changes
- Updated `src/app/layout.tsx` to import and configure the `Quintessential` and `DM_Sans` fonts via `next/font`.
- Updated `src/app/globals.css` to use CSS variables (`--font-quintessential`, `--font-dm-sans`) for reliable font application.
- Removed the old `@import` rule for Google Fonts.
- Adjusted `font-weight` on headings to `400` for optimal rendering of the Quintessential font.

### How to Verify
1.  Navigate to the Vercel preview deployment for this branch.
2.  Inspect the main headings (e.g., "Become a Founding Partner.", "Take the Helm of Your Day.").
3.  Confirm they are rendered using the **Quintessential** font.
4.  Confirm that the body text remains **DM Sans**.
5.  Ensure the page loads quickly with no font-related console errors.